### PR TITLE
Fix duplicate Client Certificate CN

### DIFF
--- a/ansible/roles/openvpn-add-client/tasks/client_keys.yml
+++ b/ansible/roles/openvpn-add-client/tasks/client_keys.yml
@@ -3,19 +3,11 @@
     path: "/home/ubuntu/vpn_users/{{ username }}"
     state: directory
 
-
-- name: set client CN
-  lineinfile:
-    dest: "{{ca_dir}}/easyrsa3/vars"
-    line: set_var EASYRSA_REQ_CN "{{username}}"
-    regexp: "#set_var EASYRSA_REQ_CN"
-
 - name: "Build client keys"
-  command: ./easyrsa --batch gen-req {{ username }} nopass
+  command: ./easyrsa --batch --req-cn="{{ username }}" gen-req {{ username }} nopass
   args:
     chdir: "{{ca_dir}}/easyrsa3"
     creates: "{{ca_dir}}/easyrsa3/pki/private/{{ username }}.key"
-
 
 - name: "Sign client keys"
   command: ./easyrsa --batch sign-req client {{ username }}


### PR DESCRIPTION
the ansible module `lineinfile` was working just for the first client certificate generated

from the second certificate and on, new lines was being generated at the `{{ca_dir}}/easyrsa3/vars` file, and just the first one was considered

all client certificates generated, although having different filenames, had all the same `CN=`